### PR TITLE
archiving recommended job boards

### DIFF
--- a/docs/resources/jobboards
+++ b/docs/resources/jobboards
@@ -1,0 +1,19 @@
+# Topic-Career-Advice Recommended Job Boards
+
+*credit due to @SteveHam for providing these sites:*
+
+- https://triplebyte.com *(likely specific to employers located around the Bay Area)*
+- https://angel.co
+
+
+*credit to @sully for these recommendations:*
+
+-https://www.vettery.com/
+-https://www.honeypot.io/ *(may be specific to Europe)*
+-https://www.workingnomads.co/jobs *(specific to remote work)*
+-https://powertofly.com/ *(specific to women)*
+-https://www.builtincolorado.com/ 
+-https://www.hackerrank.com/jobs/search
+-https://hired.com/
+
+


### PR DESCRIPTION
I wasn't sure how to add this to the resources drop down on the Denver Devs github.

The intention of this file is to archive every job board website recommended by the slack channel topic-career-advice.

Thanks!