### PR TITLE
Header Dropdown Fix to allow Dropdown to Appear on md sized devices

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -329,7 +329,7 @@ const DesktopSubNav = ({ label, href, subLabel }) => {
 const MobileNav = (loggedIn, logout, login) => {
   return (
     <Stack
-      display={{ md: "none" }}
+      display={{ lg: "none" }}
       padding={4}
       background={useColorModeValue("white", "gray.800")}
     >


### PR DESCRIPTION
I found an issue where on displays with widths between 768 and 991 pixels, the dropdown in the header would not display properly.
---
This was fixed by changing the value for displays on the Stack component from md to lg. This keeps all previous functionality, but allows users with screens of that size to use the dropdown properly.

---
Current Version
![image](https://user-images.githubusercontent.com/16121783/192466460-f52d1037-8c59-4bd2-ae11-9a944a573003.png)
Updated Version
![image](https://user-images.githubusercontent.com/16121783/192467097-9fdeecea-a7d2-455f-94c2-921de0a90c9e.png)

---
I am not sure if this is intended functionality, just something I noticed while playing with the site.