### PR TITLE
Fixed issue with readability in light mode on Job Sidebar

### DIFF
--- a/components/JobsSidebarCTA.jsx
+++ b/components/JobsSidebarCTA.jsx
@@ -12,17 +12,19 @@ export const JobsSidebarCTA = ({ isUser }) => {
             background="linear-gradient(125.04deg, #1D407C -0.1%, #4B1114 97.61%)"
             borderRadius="20px"
           >
-            <Heading marginBottom={3} size="md">
-              Want to post a job?
-            </Heading>
-            <Text marginBottom={6}>
-              All you need to do is sign up! It’s free and easy, just make sure
-              you check our{" "}
-              <Link as={NextLink} href={"/rules-and-faq"} passHref>
-                Rules and FAQ
-              </Link>{" "}
-              before posting.
-            </Text>
+            <Box color={"white"}>
+              <Heading marginBottom={3} size="md">
+                Want to post a job?
+              </Heading>
+              <Text marginBottom={6}>
+                All you need to do is sign up! It’s free and easy, just make
+                sure you check our{" "}
+                <Link as={NextLink} href={"/rules-and-faq"} passHref>
+                  Rules and FAQ
+                </Link>{" "}
+                before posting.
+              </Text>
+            </Box>
             <Button as="a" colorScheme="gray" href="/jobs/dashboard">
               Sign up
             </Button>


### PR DESCRIPTION
On the Jobs page, the box that shows that you need to sign up to create a post had a bug where when a user was in light mode the text would be black on an already dark gradient background.
---
This was fixed by wrapping the text portion of that in a box with a color prop set to white. This sets the color permanently to white and allows readability when in both light and dark modes.
---
Current Version
![image](https://user-images.githubusercontent.com/16121783/192698757-3b305976-1ea8-41ff-b288-f4ed6dc92d6d.png)
Proposed Change
![image](https://user-images.githubusercontent.com/16121783/192698796-8d185877-cdc4-4292-a0ea-859b9cd5e795.png)
---
Just something that I found while playing around again. To my knowledge this was the only area on the site that had this issue. 