### PR TITLE
fix: removes nested a tags in header to prevent header hydration issue

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -312,13 +312,12 @@ const DesktopSubNav = ({ label, href, subLabel }) => {
           rounded={"md"}
         >
           <Text
-            as="a"
             fontSize="sm"
             fontWeight={500}
             _groupHover={{ color: useColorModeValue("gray.700", "white.700") }}
             transition={"all .3s ease"}
           >
-            <LinkOverlay>{label}</LinkOverlay>
+            {label}
           </Text>
         </Box>
       </NextLink>


### PR DESCRIPTION
#149 - should clear this one up, also noticed we have a hydration bug on the job page, too. 