### PR TITLE
Refactor Metadata/SEO approach Re: Issue #141

### DIFF
--- a/components/TextPageWrapper.jsx
+++ b/components/TextPageWrapper.jsx
@@ -1,14 +1,21 @@
 import { Box } from "@chakra-ui/react";
-import Head from "next/head";
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import React from "react";
 
 import TextPageHeader from "@/components/TextPageHeader";
 
 const TextPageWrapper = ({ title, headerText, children }) => {
+  const router = useRouter();
+
   return (
     <>
-      <NextSeo title={title} />
+      <NextSeo
+        title={title}
+        openGraph={{
+          url: `https://denverdevs.org${router.asPath}`,
+        }}
+      />
       <Box
         maxWidth="80ch"
         margin="auto"

--- a/components/TextPageWrapper.jsx
+++ b/components/TextPageWrapper.jsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import Head from "next/head";
+import { NextSeo } from "next-seo";
 import React from "react";
 
 import TextPageHeader from "@/components/TextPageHeader";
@@ -7,9 +8,7 @@ import TextPageHeader from "@/components/TextPageHeader";
 const TextPageWrapper = ({ title, headerText, children }) => {
   return (
     <>
-      <Head>
-        <title>{title} | Denver Devs</title>
-      </Head>
+      <NextSeo title={title} />
       <Box
         maxWidth="80ch"
         margin="auto"

--- a/next-seo-config.js
+++ b/next-seo-config.js
@@ -5,7 +5,7 @@ const nextSeoConfig = {
     "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
   canonical: "https://denverdevs.org",
   openGraph: {
-    title: "Jobs | Denver Devs",
+    title: "Denver Devs | %s",
     description:
       "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
     type: "website",

--- a/next-seo-config.js
+++ b/next-seo-config.js
@@ -1,5 +1,12 @@
 const nextSeoConfig = {
+  charSet: "utf-8",
+  title: "Denver Devs",
+  description:
+    "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
   openGraph: {
+    title: "Jobs | Denver Devs",
+    description:
+      "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
     type: "website",
     locale: "en_US",
     url: "https://denverdevs.org/",

--- a/next-seo-config.js
+++ b/next-seo-config.js
@@ -1,8 +1,9 @@
 const nextSeoConfig = {
   charSet: "utf-8",
-  title: "Denver Devs",
+  titleTemplate: "Denver Devs | %s",
   description:
     "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
+  canonical: "https://denverdevs.org",
   openGraph: {
     title: "Jobs | Denver Devs",
     description:

--- a/next-seo-config.js
+++ b/next-seo-config.js
@@ -1,0 +1,15 @@
+const nextSeoConfig = {
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://denverdevs.org/",
+    site_name: "Denver Devs",
+  },
+  twitter: {
+    handle: "@DenverDevs",
+    site: "@DenverDevs",
+    cardType: "summary_large_image",
+  },
+};
+
+export default nextSeoConfig;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "next": "12.2.5",
     "next-plausible": "^3.4.0",
     "next-remove-imports": "^1.0.7",
+    "next-seo": "^5.5.0",
     "normalize.css": "^8.0.1",
     "pill-pity": "^0.2.2",
     "react": "^18.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,12 +4,15 @@ import "@fontsource/inter/variable.css";
 
 import { ChakraProvider } from "@chakra-ui/react";
 import PlausibleProvider from "next-plausible";
+import { DefaultSeo } from "next-seo";
 import React, { useEffect } from "react";
 
 import Layout from "@/components/Layout";
 import { UserStateProvider } from "@/context/UserContext";
 import * as ga from "@/lib/ga";
 import theme from "@/styles/theme";
+
+import nextSeoConfig from "../next-seo-config";
 
 export default function App({ Component, pageProps, router }) {
   useEffect(() => {
@@ -27,6 +30,7 @@ export default function App({ Component, pageProps, router }) {
       <ChakraProvider theme={theme}>
         <UserStateProvider>
           <Layout route={router.route}>
+            <DefaultSeo {...nextSeoConfig} />
             <Component {...pageProps} />
           </Layout>
         </UserStateProvider>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -8,11 +8,6 @@ export default class CustomDocument extends Document {
     return (
       <Html>
         <Head>
-          <meta charSet="utf-8" />
-          <meta
-            name="description"
-            content="Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area."
-          />
           <script
             async
             src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import Head from "next/head";
 import NextLink from "next/link";
+import { NextSeo } from "next-seo";
 import React from "react";
 import { FaDiscord, FaQuestionCircle, FaRocket } from "react-icons/fa";
 import { SiChakraui, SiNetlify, SiNextdotjs } from "react-icons/si";
@@ -32,6 +33,7 @@ export default function Home() {
 
   return (
     <>
+      <NextSeo title={"Home"} />
       <Box
         marginTop={{ base: "20", xl: "28" }}
         padding={{ base: "5", xl: "16" }}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -32,20 +32,6 @@ export default function Home() {
 
   return (
     <>
-      <Head>
-        <title>Denver Devs</title>
-        <meta
-          name="description"
-          content={`Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.`}
-        />
-        <meta property="og:title" content={"Jobs | Denver Devs"} />
-        <meta
-          property="og:description"
-          content={`Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.`}
-        />
-        <meta property="og:url" content={`https://denverdevs.org`} />
-        <meta property="og:type" content="website" />
-      </Head>
       <Box
         marginTop={{ base: "20", xl: "28" }}
         padding={{ base: "5", xl: "16" }}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -12,7 +12,6 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import Head from "next/head";
 import NextLink from "next/link";
 import { NextSeo } from "next-seo";
 import React from "react";

--- a/pages/jobs/[id]/index.jsx
+++ b/pages/jobs/[id]/index.jsx
@@ -1,8 +1,8 @@
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { Box, Button, Link } from "@chakra-ui/react";
-import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
+import { NextSeo } from "next-seo";
 
 import JobPostDescription from "@/components/JobPostDescription";
 import JobPostHeader from "@/components/JobPostHeader";
@@ -12,29 +12,25 @@ import { supabase } from "@/utils/lib/supabase";
 function BrowseJobPage({ job }) {
   const router = useRouter();
   const { id } = router.query;
-
+  console.log("JOB OBJECT: ", job);
   return (
     <>
-      <Head>
-        <title>
-          {job?.title} | {job?.company} | Denver Devs
-        </title>
-        <meta
-          name="description"
-          content={`Looking for a job in Denver? ${job?.company} is hiring! Check out their job posting for a ${job?.title} on Denver Devs.`}
-        />
-        <meta
-          property="og:title"
-          content={`${job?.title} | ${job?.company} | Denver Devs`}
-        />
-        <meta
-          property="og:description"
-          content={`Looking for a job in Denver? ${job?.company} is hiring! Check out their job posting for a ${job?.title} on Denver Devs.`}
-        />
-        <meta property="og:image" content={job?.image} />
-        <meta property="og:url" content={`https://denverdevs.org/jobs/${id}`} />
-        <meta property="og:type" content="website" />
-      </Head>
+      <NextSeo
+        title={`Jobs | ${job?.title} | ${job?.company}`}
+        description={`Looking for a job in Denver? ${job?.company} is hiring! Check out their job posting for a ${job?.title} on Denver Devs.`}
+        openGraph={{
+          url: `https://denverdevs.org/jobs/${id}`,
+          images: [
+            {
+              url: job?.public_logo_url,
+              width: 400,
+              height: 400,
+              alt: `${job?.company} company logo`,
+              type: "image/jpeg",
+            },
+          ],
+        }}
+      />
       <Box
         marginTop={{ base: "20", xl: "28" }}
         marginBottom={{ base: "6", xl: "20" }}

--- a/pages/jobs/[id]/index.jsx
+++ b/pages/jobs/[id]/index.jsx
@@ -12,7 +12,7 @@ import { supabase } from "@/utils/lib/supabase";
 function BrowseJobPage({ job }) {
   const router = useRouter();
   const { id } = router.query;
-  console.log("JOB OBJECT: ", job);
+
   return (
     <>
       <NextSeo

--- a/pages/jobs/dashboard.jsx
+++ b/pages/jobs/dashboard.jsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Heading } from "@chakra-ui/react";
 import Head from "next/head";
+import { NextSeo } from "next-seo";
 import React, { useEffect, useState } from "react";
 
 import Account from "@/components/Account";
@@ -34,20 +35,13 @@ export default function Dashboard() {
 
   return (
     <>
-      <Head>
-        <title>Job Dashboard | Denver Devs</title>
-        <meta
-          name="description"
-          content={`Manage your jobs on the free Denver Devs job board`}
-        />
-        <meta property="og:title" content={"Jobs | Denver Devs"} />
-        <meta
-          property="og:description"
-          content={`Manage your jobs on the free Denver Devs job board`}
-        />
-        <meta property="og:url" content={`https://denverdevs.org/dashboard/`} />
-        <meta property="og:type" content="website" />
-      </Head>
+      <NextSeo
+        title="Job Dashboard"
+        description="Manage your jobs on the free Denver Devs job board"
+        openGraph={{
+          url: "https://denverdevs.org/dashboard/",
+        }}
+      />
       <Box marginTop={["24", "32"]}>
         {!session ? (
           <Auth />

--- a/pages/jobs/dashboard.jsx
+++ b/pages/jobs/dashboard.jsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Heading } from "@chakra-ui/react";
-import Head from "next/head";
 import { NextSeo } from "next-seo";
 import React, { useEffect, useState } from "react";
 

--- a/pages/jobs/index.jsx
+++ b/pages/jobs/index.jsx
@@ -88,6 +88,9 @@ export default function BrowseJobsPage({ jobs }) {
       <NextSeo
         title={"Jobs"}
         description="Looking for a developer job in Denver? Browse jobs on our site! Submit your own for free!"
+        openGraph={{
+          url: "https://denverdevs.org/jobs",
+        }}
       />
       <Box
         marginTop={{ base: "20", xl: "28" }}

--- a/pages/jobs/index.jsx
+++ b/pages/jobs/index.jsx
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { uniqBy } from "lodash";
 import Head from "next/head";
+import { NextSeo } from "next-seo";
 import React, { useEffect, useState } from "react";
 
 import { FilterDrawer } from "@/components/FilterDrawer";
@@ -85,20 +86,10 @@ export default function BrowseJobsPage({ jobs }) {
 
   return (
     <>
-      <Head>
-        <title>Jobs | Denver Devs</title>
-        <meta
-          name="description"
-          content={`Looking for a developer job in Denver? Browse jobs on our site! Submit your own for free!`}
-        />
-        <meta property="og:title" content={"Jobs | Denver Devs"} />
-        <meta
-          property="og:description"
-          content={`Looking for a developer job in Denver? Browse jobs on our site! Submit your own for free!`}
-        />
-        <meta property="og:url" content={`https://denverdevs.org/jobs/`} />
-        <meta property="og:type" content="website" />
-      </Head>
+      <NextSeo
+        title={"Jobs"}
+        description="Looking for a developer job in Denver? Browse jobs on our site! Submit your own for free!"
+      />
       <Box
         marginTop={{ base: "20", xl: "28" }}
         marginBottom={{ base: "6", xl: "20" }}

--- a/pages/jobs/index.jsx
+++ b/pages/jobs/index.jsx
@@ -10,7 +10,6 @@ import {
   WrapItem,
 } from "@chakra-ui/react";
 import { uniqBy } from "lodash";
-import Head from "next/head";
 import { NextSeo } from "next-seo";
 import React, { useEffect, useState } from "react";
 

--- a/pages/jobs/post-job-success.jsx
+++ b/pages/jobs/post-job-success.jsx
@@ -12,56 +12,56 @@ import {
   UnorderedList,
   useColorModeValue,
 } from "@chakra-ui/react";
-import Head from "next/head";
 import NextLink from "next/link";
+import { NextSeo } from "next-seo";
 import React from "react";
 
 const PostJobSuccessPage = () => {
   return (
-    <Flex flexDirection={{ base: "column", xl: "row" }} marginY="24">
-      <Head>
-        <title>Success | Denver Devs Job Board</title>
-      </Head>
-      <Box
-        maxWidth="80ch"
-        margin="auto"
-        padding={["4", "8"]}
-        borderWidth="1px"
-        borderRadius="md"
-      >
-        <Stack spacing="6">
-          <Heading>Success! 🎉</Heading>
-          <Text>
-            Thanks for submitting your job post. We&apos;re going to review it
-            and make sure everything looks good, if all goes well you should see
-            it on the site within 24 hours.
-          </Text>
-          <Text>
-            We&apos;ll reach out to the contact email provided if we see any
-            issues with the job post.
-          </Text>
+    <>
+      <NextSeo title="Job Board | Success" />
+      <Flex flexDirection={{ base: "column", xl: "row" }} marginY="24">
+        <Box
+          maxWidth="80ch"
+          margin="auto"
+          padding={["4", "8"]}
+          borderWidth="1px"
+          borderRadius="md"
+        >
+          <Stack spacing="6">
+            <Heading>Success! 🎉</Heading>
+            <Text>
+              Thanks for submitting your job post. We&apos;re going to review it
+              and make sure everything looks good, if all goes well you should
+              see it on the site within 24 hours.
+            </Text>
+            <Text>
+              We&apos;ll reach out to the contact email provided if we see any
+              issues with the job post.
+            </Text>
 
-          <HStack spacing="4">
-            <Link
-              as={NextLink}
-              _hover={{ textDecoration: "none" }}
-              href="/jobs/dashboard"
-              size="sm"
-            >
-              <Button colorScheme="gray">View your jobs</Button>
-            </Link>
-            <Link
-              as={NextLink}
-              _hover={{ textDecoration: "none" }}
-              href="/jobs/post-job"
-              size="sm"
-            >
-              <Button colorScheme="gray">Submit another job post</Button>
-            </Link>
-          </HStack>
-        </Stack>
-      </Box>
-    </Flex>
+            <HStack spacing="4">
+              <Link
+                as={NextLink}
+                _hover={{ textDecoration: "none" }}
+                href="/jobs/dashboard"
+                size="sm"
+              >
+                <Button colorScheme="gray">View your jobs</Button>
+              </Link>
+              <Link
+                as={NextLink}
+                _hover={{ textDecoration: "none" }}
+                href="/jobs/post-job"
+                size="sm"
+              >
+                <Button colorScheme="gray">Submit another job post</Button>
+              </Link>
+            </HStack>
+          </Stack>
+        </Box>
+      </Flex>
+    </>
   );
 };
 

--- a/pages/jobs/post-job.jsx
+++ b/pages/jobs/post-job.jsx
@@ -28,8 +28,8 @@ import {
 } from "@chakra-ui/react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Select } from "chakra-react-select";
-import Head from "next/head";
 import { useRouter } from "next/router";
+import { NextSeo } from "next-seo";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { v4 as uuid } from "uuid";
@@ -170,379 +170,387 @@ const PostJobPage = () => {
   });
 
   return (
-    <Box marginTop={["24", "32"]}>
-      <Head>
-        <title>Post a Job | Denver Devs Job Board</title>
-        <meta
-          name="description"
-          content={`Post a job for free on Denver Devs.`}
-        />
-        <meta property="og:title" content={"Jobs | Denver Devs"} />
-        <meta
-          property="og:description"
-          content={`Post a job for free on Denver Devs.`}
-        />
-        <meta property="og:url" content={`https://denverdevs.org/post-job/`} />
-        <meta property="og:type" content="website" />
-      </Head>
-      <Stack alignItems={"center"} spacing={4}>
-        {!user && <Auth redirectPath="/jobs/post-job" />}
-        <Box
-          maxWidth="80ch"
-          padding={["4", "8"]}
-          borderWidth="1px"
-          borderRadius="md"
-        >
-          <Alert
-            marginBottom="8"
-            padding="4"
+    <>
+      <NextSeo
+        title="Job Board | Post a Job"
+        description="Post a job for free on Denver Devs."
+        openGraph={{
+          url: "https://denverdevs.org/post-job/",
+        }}
+      />
+      <Box marginTop={["24", "32"]}>
+        <Stack alignItems={"center"} spacing={4}>
+          {!user && <Auth redirectPath="/jobs/post-job" />}
+          <Box
+            maxWidth="80ch"
+            padding={["4", "8"]}
+            borderWidth="1px"
             borderRadius="md"
-            status="warning"
           >
-            <AlertIcon />
+            <Alert
+              marginBottom="8"
+              padding="4"
+              borderRadius="md"
+              status="warning"
+            >
+              <AlertIcon />
 
-            <Text marginBottom="2">
-              You must be an employee or directly responsible for hiring or
-              recruiting at the company you are posting for. No third-party
-              postings or &quot;sharing to share&quot;.
-            </Text>
-          </Alert>
-          <Alert
-            marginBottom="8"
-            padding="4"
-            borderRadius="md"
-            status="warning"
-          >
-            <AlertIcon />
+              <Text marginBottom="2">
+                You must be an employee or directly responsible for hiring or
+                recruiting at the company you are posting for. No third-party
+                postings or &quot;sharing to share&quot;.
+              </Text>
+            </Alert>
+            <Alert
+              marginBottom="8"
+              padding="4"
+              borderRadius="md"
+              status="warning"
+            >
+              <AlertIcon />
 
-            <Text marginBottom="2">
-              Adhere to Colorado law regarding job post information as outlined
-              in the{" "}
-              <Link href="https://leg.colorado.gov/bills/sb19-085" isExternal>
-                Equal Pay for Equal Work Act <ExternalLinkIcon mx="2px" />
-              </Link>
-              . You must proide a minimum and maxiumum compensation amount, and
-              compensation type (salary or hourly) for your post to be approved.
-            </Text>
-          </Alert>
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            style={{ display: "flex", flexDirection: "column" }}
-          >
-            <Stack spacing="8">
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.title}
-                isRequired
-              >
-                <FormLabel htmlFor="title">Job title</FormLabel>
-                <Input
-                  id="title"
-                  {...register("title", { required: true })}
-                  disabled={!user}
-                />
-                <FormErrorMessage>
-                  {errors.title && "This field is required."}
-                </FormErrorMessage>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.company}
-                isRequired
-              >
-                <FormLabel htmlFor="company">Company name</FormLabel>
-                <Input
-                  type="text"
-                  {...register("company", { required: true })}
-                  disabled={!user}
-                />
-                <FormErrorMessage>
-                  {errors.company && "This field is required."}
-                </FormErrorMessage>
-              </FormControl>
-
-              <FormControl isDisabled={!user} isInvalid={errors.url} isRequired>
-                <FormLabel htmlFor="job_url">Link to job description</FormLabel>
-                <Input
-                  type="job_url"
-                  {...register("job_url", { required: true })}
-                  disabled={!user}
-                  placeholder="https://..."
-                />
-                <FormErrorMessage>{errors.url}</FormErrorMessage>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.location?.ref}
-                isRequired
-              >
-                <FormLabel>Location</FormLabel>
-                <Controller
-                  control={control}
-                  name="location"
-                  rules={{ required: true }}
-                  // TODO: something about setting this to required, submitting and clearing causes it to fully error out
-                  render={({ field }) => (
-                    <Select
-                      isMulti
-                      inputRef={field.ref}
-                      options={locationOptions}
-                      value={field.value}
-                      onChange={field.onChange}
-                      placeholder="Select applicable location(s)"
-                      closeMenuOnSelect={false}
-                      selectedOptionStyle="check"
-                      hideSelectedOptions={false}
-                      disabled={!user}
-                      isOptionDisabled={(option) => field?.value?.length >= 3}
-                    />
-                  )}
-                />
-                <FormHelperText>
-                  Select locations to help with searching. Select up to three
-                  tags.
-                </FormHelperText>
-                <FormErrorMessage>
-                  {errors.location &&
-                    "This field is required, please select up to three options"}
-                </FormErrorMessage>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.location_type}
-                isRequired
-              >
-                <FormLabel htmlFor="location">Commute</FormLabel>
-                <Controller
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <RadioGroup
-                      disabled={!user}
-                      onChange={field.onChange}
-                      value={field.value}
-                    >
-                      <Wrap spacing="4">
-                        <WrapItem>
-                          <Radio ref={field.ref} value="remote">
-                            Remote
-                          </Radio>
-                        </WrapItem>
-                        <WrapItem>
-                          <Radio ref={field.ref} value="hybrid">
-                            Remote + in-office
-                          </Radio>
-                        </WrapItem>
-                        <WrapItem>
-                          <Radio ref={field.ref} value="on-site">
-                            In-office only
-                          </Radio>
-                        </WrapItem>
-                      </Wrap>
-                    </RadioGroup>
-                  )}
-                  control={control}
-                  name="location_type"
-                />
-                <FormErrorMessage>
-                  {errors.location_type && "This field is required."}
-                </FormErrorMessage>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.compensation_type}
-                isRequired
-              >
-                <FormLabel htmlFor="compensation_type">
-                  Compensation type
-                </FormLabel>
-                <Controller
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <RadioGroup
-                      disabled={!user}
-                      onChange={field.onChange}
-                      value={field.value}
-                    >
-                      <Wrap spacing="4">
-                        <WrapItem>
-                          <Radio ref={field.ref} value="salary">
-                            Salary
-                          </Radio>
-                        </WrapItem>
-                        <WrapItem>
-                          <Radio ref={field.ref} value="hourly">
-                            Hourly
-                          </Radio>
-                        </WrapItem>
-                      </Wrap>
-                    </RadioGroup>
-                  )}
-                  control={control}
-                  name="compensation_type"
-                />
-                <FormErrorMessage>
-                  {errors.compensation_type && "This field is required."}
-                </FormErrorMessage>
-              </FormControl>
-
-              <Flex gap="10">
+              <Text marginBottom="2">
+                Adhere to Colorado law regarding job post information as
+                outlined in the{" "}
+                <Link href="https://leg.colorado.gov/bills/sb19-085" isExternal>
+                  Equal Pay for Equal Work Act <ExternalLinkIcon mx="2px" />
+                </Link>
+                . You must proide a minimum and maxiumum compensation amount,
+                and compensation type (salary or hourly) for your post to be
+                approved.
+              </Text>
+            </Alert>
+            <form
+              onSubmit={handleSubmit(onSubmit)}
+              style={{ display: "flex", flexDirection: "column" }}
+            >
+              <Stack spacing="8">
                 <FormControl
                   isDisabled={!user}
-                  isInvalid={errors.compensation_min}
+                  isInvalid={errors.title}
                   isRequired
                 >
-                  <FormLabel htmlFor="compensation_min">
-                    Compensation minimum
+                  <FormLabel htmlFor="title">Job title</FormLabel>
+                  <Input
+                    id="title"
+                    {...register("title", { required: true })}
+                    disabled={!user}
+                  />
+                  <FormErrorMessage>
+                    {errors.title && "This field is required."}
+                  </FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.company}
+                  isRequired
+                >
+                  <FormLabel htmlFor="company">Company name</FormLabel>
+                  <Input
+                    type="text"
+                    {...register("company", { required: true })}
+                    disabled={!user}
+                  />
+                  <FormErrorMessage>
+                    {errors.company && "This field is required."}
+                  </FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.url}
+                  isRequired
+                >
+                  <FormLabel htmlFor="job_url">
+                    Link to job description
                   </FormLabel>
-                  <InputGroup>
-                    <InputLeftElement zIndex="0" pointerEvents="none">
-                      $
-                    </InputLeftElement>
-                    <Input
-                      type="number"
-                      {...register("compensation_min", {
-                        required: true,
-                      })}
-                      disabled={!user}
-                      placeholder="USD"
-                    />
-                  </InputGroup>
-                  <FormErrorMessage>{errors.compensation_min}</FormErrorMessage>
+                  <Input
+                    type="job_url"
+                    {...register("job_url", { required: true })}
+                    disabled={!user}
+                    placeholder="https://..."
+                  />
+                  <FormErrorMessage>{errors.url}</FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.location?.ref}
+                  isRequired
+                >
+                  <FormLabel>Location</FormLabel>
+                  <Controller
+                    control={control}
+                    name="location"
+                    rules={{ required: true }}
+                    // TODO: something about setting this to required, submitting and clearing causes it to fully error out
+                    render={({ field }) => (
+                      <Select
+                        isMulti
+                        inputRef={field.ref}
+                        options={locationOptions}
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Select applicable location(s)"
+                        closeMenuOnSelect={false}
+                        selectedOptionStyle="check"
+                        hideSelectedOptions={false}
+                        disabled={!user}
+                        isOptionDisabled={(option) => field?.value?.length >= 3}
+                      />
+                    )}
+                  />
                   <FormHelperText>
-                    Minimum and maximum (range) required per Colorado law.
+                    Select locations to help with searching. Select up to three
+                    tags.
+                  </FormHelperText>
+                  <FormErrorMessage>
+                    {errors.location &&
+                      "This field is required, please select up to three options"}
+                  </FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.location_type}
+                  isRequired
+                >
+                  <FormLabel htmlFor="location">Commute</FormLabel>
+                  <Controller
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                      <RadioGroup
+                        disabled={!user}
+                        onChange={field.onChange}
+                        value={field.value}
+                      >
+                        <Wrap spacing="4">
+                          <WrapItem>
+                            <Radio ref={field.ref} value="remote">
+                              Remote
+                            </Radio>
+                          </WrapItem>
+                          <WrapItem>
+                            <Radio ref={field.ref} value="hybrid">
+                              Remote + in-office
+                            </Radio>
+                          </WrapItem>
+                          <WrapItem>
+                            <Radio ref={field.ref} value="on-site">
+                              In-office only
+                            </Radio>
+                          </WrapItem>
+                        </Wrap>
+                      </RadioGroup>
+                    )}
+                    control={control}
+                    name="location_type"
+                  />
+                  <FormErrorMessage>
+                    {errors.location_type && "This field is required."}
+                  </FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.compensation_type}
+                  isRequired
+                >
+                  <FormLabel htmlFor="compensation_type">
+                    Compensation type
+                  </FormLabel>
+                  <Controller
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                      <RadioGroup
+                        disabled={!user}
+                        onChange={field.onChange}
+                        value={field.value}
+                      >
+                        <Wrap spacing="4">
+                          <WrapItem>
+                            <Radio ref={field.ref} value="salary">
+                              Salary
+                            </Radio>
+                          </WrapItem>
+                          <WrapItem>
+                            <Radio ref={field.ref} value="hourly">
+                              Hourly
+                            </Radio>
+                          </WrapItem>
+                        </Wrap>
+                      </RadioGroup>
+                    )}
+                    control={control}
+                    name="compensation_type"
+                  />
+                  <FormErrorMessage>
+                    {errors.compensation_type && "This field is required."}
+                  </FormErrorMessage>
+                </FormControl>
+
+                <Flex gap="10">
+                  <FormControl
+                    isDisabled={!user}
+                    isInvalid={errors.compensation_min}
+                    isRequired
+                  >
+                    <FormLabel htmlFor="compensation_min">
+                      Compensation minimum
+                    </FormLabel>
+                    <InputGroup>
+                      <InputLeftElement zIndex="0" pointerEvents="none">
+                        $
+                      </InputLeftElement>
+                      <Input
+                        type="number"
+                        {...register("compensation_min", {
+                          required: true,
+                        })}
+                        disabled={!user}
+                        placeholder="USD"
+                      />
+                    </InputGroup>
+                    <FormErrorMessage>
+                      {errors.compensation_min}
+                    </FormErrorMessage>
+                    <FormHelperText>
+                      Minimum and maximum (range) required per Colorado law.
+                    </FormHelperText>
+                  </FormControl>
+                  <FormControl
+                    isDisabled={!user}
+                    isInvalid={errors.compensation_max}
+                    isRequired
+                  >
+                    <FormLabel htmlFor="compensation_max">
+                      Compensation maximum
+                    </FormLabel>
+                    <InputGroup>
+                      <InputLeftElement zIndex="0" pointerEvents="none">
+                        $
+                      </InputLeftElement>
+                      <Input
+                        type="number"
+                        {...register("compensation_max", {
+                          required: true,
+                        })}
+                        disabled={!user}
+                        placeholder="USD"
+                      />
+                    </InputGroup>
+                    <FormErrorMessage>
+                      {errors.compensation_max}
+                    </FormErrorMessage>
+                  </FormControl>
+                </Flex>
+
+                <FormControl isDisabled={!user} isInvalid={errors.logo}>
+                  <FormLabel htmlFor="logo">Upload a company logo</FormLabel>
+                  <ImageUpload
+                    bucket="logos"
+                    url={logoUrl}
+                    size={150}
+                    onUpload={(url) => {
+                      setLogoUrl(url);
+                      getPublicUrl(url);
+                    }}
+                    disabled={!user}
+                  />
+                  <FormHelperText>
+                    Background will be white, you can preview below
+                  </FormHelperText>
+                  <FormErrorMessage>{errors.logo}</FormErrorMessage>
+                </FormControl>
+
+                <FormControl
+                  isDisabled={!user}
+                  isInvalid={errors.job_tags}
+                  isRequired
+                >
+                  <FormLabel>Tags</FormLabel>
+                  <Controller
+                    control={control}
+                    rules={{ required: true }}
+                    name="job_tags"
+                    render={({ field }) => (
+                      <Select
+                        isMulti
+                        options={jobTagsArray}
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Select applicable tags"
+                        closeMenuOnSelect={false}
+                        selectedOptionStyle="check"
+                        hideSelectedOptions={false}
+                        disabled={!user}
+                        isOptionDisabled={(option) => field?.value?.length >= 6}
+                      />
+                    )}
+                  />
+                  <FormHelperText>
+                    Select tags to help with searching. Select up to six tags.
                   </FormHelperText>
                 </FormControl>
+
                 <FormControl
                   isDisabled={!user}
-                  isInvalid={errors.compensation_max}
+                  isInvalid={errors.job_description}
                   isRequired
                 >
-                  <FormLabel htmlFor="compensation_max">
-                    Compensation maximum
+                  <FormLabel htmlFor="job_description">
+                    Job description
                   </FormLabel>
-                  <InputGroup>
-                    <InputLeftElement zIndex="0" pointerEvents="none">
-                      $
-                    </InputLeftElement>
-                    <Input
-                      type="number"
-                      {...register("compensation_max", {
-                        required: true,
-                      })}
-                      disabled={!user}
-                      placeholder="USD"
-                    />
-                  </InputGroup>
-                  <FormErrorMessage>{errors.compensation_max}</FormErrorMessage>
+                  <Textarea
+                    id="job_description"
+                    placeholder="Enter job description here..."
+                    {...register("job_description", {
+                      required: true,
+                    })}
+                    resize="none"
+                    isDisabled={!user}
+                  />
+                  <Box alignItems={"flex-end"} display={"flex"} my={1}>
+                    {!errors.job_description ? (
+                      <FormHelperText>
+                        {watchedFormData.job_description?.length}/
+                        {MAX_JOB_DESCRIPTION_LENGTH} characters
+                      </FormHelperText>
+                    ) : (
+                      <FormErrorMessage>
+                        {watchedFormData.job_description?.length}/
+                        {MAX_JOB_DESCRIPTION_LENGTH} characters
+                      </FormErrorMessage>
+                    )}
+                  </Box>
                 </FormControl>
-              </Flex>
 
-              <FormControl isDisabled={!user} isInvalid={errors.logo}>
-                <FormLabel htmlFor="logo">Upload a company logo</FormLabel>
-                <ImageUpload
-                  bucket="logos"
-                  url={logoUrl}
-                  size={150}
-                  onUpload={(url) => {
-                    setLogoUrl(url);
-                    getPublicUrl(url);
-                  }}
-                  disabled={!user}
-                />
-                <FormHelperText>
-                  Background will be white, you can preview below
-                </FormHelperText>
-                <FormErrorMessage>{errors.logo}</FormErrorMessage>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.job_tags}
-                isRequired
-              >
-                <FormLabel>Tags</FormLabel>
-                <Controller
-                  control={control}
-                  rules={{ required: true }}
-                  name="job_tags"
-                  render={({ field }) => (
-                    <Select
-                      isMulti
-                      options={jobTagsArray}
-                      value={field.value}
-                      onChange={field.onChange}
-                      placeholder="Select applicable tags"
-                      closeMenuOnSelect={false}
-                      selectedOptionStyle="check"
-                      hideSelectedOptions={false}
-                      disabled={!user}
-                      isOptionDisabled={(option) => field?.value?.length >= 6}
-                    />
-                  )}
-                />
-                <FormHelperText>
-                  Select tags to help with searching. Select up to six tags.
-                </FormHelperText>
-              </FormControl>
-
-              <FormControl
-                isDisabled={!user}
-                isInvalid={errors.job_description}
-                isRequired
-              >
-                <FormLabel htmlFor="job_description">Job description</FormLabel>
-                <Textarea
-                  id="job_description"
-                  placeholder="Enter job description here..."
-                  {...register("job_description", {
-                    required: true,
-                  })}
-                  resize="none"
-                  isDisabled={!user}
-                />
-                <Box alignItems={"flex-end"} display={"flex"} my={1}>
-                  {!errors.job_description ? (
-                    <FormHelperText>
-                      {watchedFormData.job_description?.length}/
-                      {MAX_JOB_DESCRIPTION_LENGTH} characters
-                    </FormHelperText>
-                  ) : (
-                    <FormErrorMessage>
-                      {watchedFormData.job_description?.length}/
-                      {MAX_JOB_DESCRIPTION_LENGTH} characters
-                    </FormErrorMessage>
-                  )}
+                <Box>
+                  <Heading marginTop="0" marginBottom="2" size="med">
+                    Preview
+                  </Heading>
+                  <JobCardPreview
+                    job={watchedFormData}
+                    publicLogoUrl={publicLogoUrl}
+                  />
                 </Box>
-              </FormControl>
 
-              <Box>
-                <Heading marginTop="0" marginBottom="2" size="med">
-                  Preview
-                </Heading>
-                <JobCardPreview
-                  job={watchedFormData}
-                  publicLogoUrl={publicLogoUrl}
-                />
-              </Box>
-
-              {isSubmitting ? (
-                <Button isLoading loadingText="Submitting" variant="outline">
-                  Submitting, please wait
-                </Button>
-              ) : (
-                <Button disabled={formSubmitSuccess || !user} type="submit">
-                  Submit for review
-                </Button>
-              )}
-            </Stack>
-          </form>
-        </Box>
-      </Stack>
-    </Box>
+                {isSubmitting ? (
+                  <Button isLoading loadingText="Submitting" variant="outline">
+                    Submitting, please wait
+                  </Button>
+                ) : (
+                  <Button disabled={formSubmitSuccess || !user} type="submit">
+                    Submit for review
+                  </Button>
+                )}
+              </Stack>
+            </form>
+          </Box>
+        </Stack>
+      </Box>
+    </>
   );
 };
 

--- a/pages/update/[slug].jsx
+++ b/pages/update/[slug].jsx
@@ -36,9 +36,17 @@ export async function getStaticProps({ params: { slug } }) {
 }
 
 export default function Update({ frontmatter, content }) {
+  const router = useRouter();
+
   return (
     <>
-      <NextSeo title={frontmatter.title} description={frontmatter.snippet} />
+      <NextSeo
+        title={frontmatter.title}
+        description={frontmatter.snippet}
+        openGraph={{
+          url: `https://denverdevs.org${router.asPath}`,
+        }}
+      />
       <Container maxWidth={"container.md"} marginTop={{ base: "10", xl: "20" }}>
         <NextLink href="/updates" passHref>
           <Link marginTop="auto" _hover={{ textDecoration: "none" }}>

--- a/pages/update/[slug].jsx
+++ b/pages/update/[slug].jsx
@@ -3,7 +3,6 @@ import { Box, Button, Container, Link } from "@chakra-ui/react";
 import { Prose } from "@nikolovlazar/chakra-ui-prose";
 import matter from "gray-matter";
 import md from "markdown-it";
-import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";

--- a/pages/update/[slug].jsx
+++ b/pages/update/[slug].jsx
@@ -37,7 +37,6 @@ export async function getStaticProps({ params: { slug } }) {
 }
 
 export default function Update({ frontmatter, content }) {
-  console.log("FRONTMATTER: ", frontmatter);
   return (
     <>
       <NextSeo title={frontmatter.title} description={frontmatter.snippet} />

--- a/pages/update/[slug].jsx
+++ b/pages/update/[slug].jsx
@@ -6,6 +6,7 @@ import md from "markdown-it";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
+import { NextSeo } from "next-seo";
 
 import Layout from "@/components/Layout";
 
@@ -36,19 +37,23 @@ export async function getStaticProps({ params: { slug } }) {
 }
 
 export default function Update({ frontmatter, content }) {
+  console.log("FRONTMATTER: ", frontmatter);
   return (
-    <Container maxWidth={"container.md"} marginTop={{ base: "10", xl: "20" }}>
-      <NextLink href="/updates" passHref>
-        <Link marginTop="auto" _hover={{ textDecoration: "none" }}>
-          <Button leftIcon={<ArrowBackIcon />} size="sm" variant="ghost">
-            Back to All Updates
-          </Button>
-        </Link>
-      </NextLink>
-      <Prose>
-        <h1>{frontmatter.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: md().render(content) }} />
-      </Prose>
-    </Container>
+    <>
+      <NextSeo title={frontmatter.title} description={frontmatter.snippet} />
+      <Container maxWidth={"container.md"} marginTop={{ base: "10", xl: "20" }}>
+        <NextLink href="/updates" passHref>
+          <Link marginTop="auto" _hover={{ textDecoration: "none" }}>
+            <Button leftIcon={<ArrowBackIcon />} size="sm" variant="ghost">
+              Back to All Updates
+            </Button>
+          </Link>
+        </NextLink>
+        <Prose>
+          <h1>{frontmatter.title}</h1>
+          <div dangerouslySetInnerHTML={{ __html: md().render(content) }} />
+        </Prose>
+      </Container>
+    </>
   );
 }

--- a/pages/updates.jsx
+++ b/pages/updates.jsx
@@ -6,6 +6,7 @@ import matter from "gray-matter";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
+import { NextSeo } from "next-seo";
 import React from "react";
 
 import Layout from "@/components/Layout";
@@ -44,9 +45,7 @@ const Posts = ({ posts }) => {
 
   return (
     <>
-      <Head>
-        <title>Denver Devs - Updates</title>
-      </Head>
+      <NextSeo title={"Updates"} />
       <Container marginTop={{ base: "20", xl: "28" }}>
         <Heading marginBottom="2" size="md">
           Updates

--- a/pages/updates.jsx
+++ b/pages/updates.jsx
@@ -44,7 +44,12 @@ const Posts = ({ posts }) => {
 
   return (
     <>
-      <NextSeo title={"Updates"} />
+      <NextSeo
+        title={"Updates"}
+        openGraph={{
+          url: "https://denverdevs.org/updates",
+        }}
+      />
       <Container marginTop={{ base: "20", xl: "28" }}>
         <Heading marginBottom="2" size="md">
           Updates

--- a/pages/updates.jsx
+++ b/pages/updates.jsx
@@ -3,7 +3,6 @@ import { format } from "date-fns";
 import parseISO from "date-fns/parseISO";
 import toDate from "date-fns/toDate";
 import matter from "gray-matter";
-import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { NextSeo } from "next-seo";

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# Allow all crawlers
+User-agent: *
+Allow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# Allow all crawlers
-User-agent: *
-Allow: /

--- a/yarn.lock
+++ b/yarn.lock
@@ -5835,6 +5835,11 @@ next-remove-imports@^1.0.7:
     babel-loader "^8.2.2"
     babel-plugin-transform-remove-imports "^1.5.4"
 
+next-seo@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.5.0.tgz#12bdfce60a6ae098f49617357a166c2d44dbc29e"
+  integrity sha512-5ouBHFtx8YrSDW44lj0qIEQ+oMcz6stgoITB+SqHUZbhgizoJsyLmq73gJ0lxtEKpcN8vG2QgRIJfdb8OAPChw==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
This PR introduces the [Next SEO](https://www.npmjs.com/package/next-seo) plugin to help manage metadata site-wide.

The file `next-seo-config.js` defines the metadata default values for the site and is passed as a prop to `DefaultSeo` in `_app.js`. `DefaultSeo` and `NextSeo` render out the tags in the markup for SEO.

```
const nextSeoConfig = {
  charSet: "utf-8",
  titleTemplate: "Denver Devs | %s",
  description:
    "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
  canonical: "https://denverdevs.org",
  openGraph: {
    title: "Denver Devs | %s",
    description:
      "Denver Devs is an online Discord community for software engineers and tech industry professionals in the Denver, Colorado area.",
    type: "website",
    locale: "en_US",
    url: "https://denverdevs.org/",
    site_name: "Denver Devs",
  },
  twitter: {
    handle: "@DenverDevs",
    site: "@DenverDevs",
    cardType: "summary_large_image",
  },
};
```

`NextSeo` is imported on specific pages where default metadata values need to be overwritten. 

