### PR TITLE
Fixes typo "Sever"

### DIFF
--- a/pages/resources/rules.jsx
+++ b/pages/resources/rules.jsx
@@ -23,7 +23,7 @@ export default function RulesAndFaq() {
   ];
   return (
     <TextPageWrapper
-      headerText="Discord Sever Rules"
+      headerText="Discord Server Rules"
       title="Discord Server Rules"
     >
       <Text my={["4", "8"]} fontSize="lg">


### PR DESCRIPTION
Discord `Server` instead of Discord `Sever`
#143 